### PR TITLE
모바일(좁은 너비)에서 보이는 nav button 색상 반투명화

### DIFF
--- a/_sass/custom/_custom.scss
+++ b/_sass/custom/_custom.scss
@@ -117,3 +117,13 @@ a:visited {
   color: #555555;
   /* 활성화된 링크는 검은색으로 표시 */
 }
+
+/* Mobile navigation bar style override */
+@media screen and (max-width: 600px) {
+  .site-nav {
+    background-color: rgba(255, 255, 255, 0.6); // half transparent white
+    backdrop-filter: blur(8px); // blur effect
+    border: 1px dashed #e0e0e0;
+    font-size: 1.1rem;
+  }
+}


### PR DESCRIPTION
후
<img width="567" height="305" alt="image" src="https://github.com/user-attachments/assets/4162f6d7-a974-4b69-bf8a-505ecdb83c63" />

전
<img width="567" height="305" alt="image" src="https://github.com/user-attachments/assets/1d75d76b-da1c-4e3e-ace2-ca5693f4da26" />
